### PR TITLE
Update deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ maintenance = { status = "actively-developed" }
 
 [features]
 strip = ["vk-shader-macros-impl/strip"] # Omit debug info from generated SPIR-V by default
+build-from-source = ["vk-shader-macros-impl/build-from-source"] # Force shaderc to be built from source
 
 [dependencies]
 vk-shader-macros-impl = { path = "impl", version = "0.2.1" }

--- a/README.md
+++ b/README.md
@@ -33,9 +33,11 @@ without requiring copying or unsafe code.
 
 This crate currently depends on the foreign
 [shaderc](https://github.com/google/shaderc/) library. By default, it
-will be compiled automatically, requiring git, cmake, python 3, and a
-supported C++ compiler to be available in the build environment. A
-pre-compiled shaderc can be used by disabling the crate's default
-features, but care must be taken to use a version that is
-binary-compatible with the one checked out by [the shaderc
-crate](https://github.com/google/shaderc-rs).
+will attempt to use an installed shaderc library. However if it does
+not exist, it will fall back to building from source, requiring git,
+cmake, python 3, and a supported C++ compiler to be available in the
+build environment. When using a pre-compiled shaderc, care must be
+taken to use a version that is binary-compatible with the one checked
+out by [the shaderc crate](https://github.com/google/shaderc-rs).
+You can force shaderc to be built from source by enabling the
+`build-from-source` feature on vk-shader-macros.

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -11,10 +11,11 @@ proc-macro = true
 
 [features]
 strip = []
+build-from-source = ["shaderc/build-from-source"]
 
 [dependencies]
-syn = { version = "0.15.26", default-features = false, features = [ "parsing", "proc-macro", "derive" ] }
-quote = "0.6.11"
-proc-macro2 = "0.4.27"
+syn = { version = "1.0.2", default-features = false, features = [ "parsing", "proc-macro", "derive" ] }
+quote = "1.0.1"
+proc-macro2 = "1.0.1"
 proc-macro-hack = "0.5.4"
-shaderc = "0.5"
+shaderc = "0.6.1"

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -56,7 +56,7 @@ impl Parse for IncludeGlsl {
                 "version" => {
                     input.parse::<Token![:]>()?;
                     let x = input.parse::<LitInt>()?;
-                    options.set_forced_version_profile(x.value() as u32, shaderc::GlslProfile::None);
+                    options.set_forced_version_profile(x.base10_parse::<u32>()?, shaderc::GlslProfile::None);
                 }
                 "strip" => {
                     debug = false;


### PR DESCRIPTION
It looks like the default behavior of how shaderc-rs attempts to build shaderc has changed, so I updated the documentation to reflect this and reexposed the build-from-source feature in vk-shader-macros.