### PR TITLE
Update to shaderc v0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,5 @@ build-from-source = ["shaderc/build-from-source"] # Force shaderc to be built fr
 syn = { version = "2.0", default-features = false, features = [ "parsing", "proc-macro", "derive" ] }
 quote = "1.0.17"
 proc-macro2 = "1.0.36"
+# `prefer-static-linking` avoids errors when using the proc macro with rust-analyzer.
 shaderc = { version = "0.8.3", features = ["prefer-static-linking"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,4 @@ build-from-source = ["shaderc/build-from-source"] # Force shaderc to be built fr
 syn = { version = "2.0", default-features = false, features = [ "parsing", "proc-macro", "derive" ] }
 quote = "1.0.17"
 proc-macro2 = "1.0.36"
-# `prefer-static-linking` avoids errors when using the proc macro with rust-analyzer.
-shaderc = { version = "0.8.3", features = ["prefer-static-linking"] }
+shaderc = "0.8.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,4 @@ build-from-source = ["shaderc/build-from-source"] # Force shaderc to be built fr
 syn = { version = "2.0", default-features = false, features = [ "parsing", "proc-macro", "derive" ] }
 quote = "1.0.17"
 proc-macro2 = "1.0.36"
-shaderc = "0.7.4"
+shaderc = { version = "0.8.3", features = ["prefer-static-linking"] }

--- a/src/build.rs
+++ b/src/build.rs
@@ -191,7 +191,7 @@ impl Builder {
             })
             .unwrap_or(shaderc::ShaderKind::InferFromSource);
 
-        let mut compiler = shaderc::Compiler::new().unwrap();
+        let compiler = shaderc::Compiler::new().unwrap();
         let out = compiler
             .compile_into_spirv(&src, kind, &src_name, "main", Some(&options))
             .map_err(|e| syn::Error::new(src_span, e))?;


### PR DESCRIPTION
`rust-analyzer` currently doesn't really like this crate. Every usage of one of the macros leads to errors because rust-analyzer is unable to find `libshaderc_shared.1.dylib`:

> proc macro not expanded: Cannot create expander for /Users/tomaka/Projets/tgst2/target/debug/deps/libvk_shader_macros-8a38c4c9c0cb071c.dylib: dlopen(/Users/tomaka/Projets/tgst2/target/debug/deps/libvk_shader_macros-8a38c4c9c0cb071c.dylib, 0x000A): Library not loaded: @rpath/libshaderc_shared.1.dylib
  Referenced from: <67B6DE67-AB28-3E46-BB6B-A0C134A273EE> /Users/tomaka/Projets/tgst2/target/debug/deps/libvk_shader_macros-8a38c4c9c0cb071c.dylib
  Reason: tried: '/Users/tomaka/.rustup/toolchains/stable-aarch64-apple-darwin/libexec/../lib/libshaderc_shared.1.dylib' (no such file), '/Users/tomaka/.rustup/toolchains/stable-aarch64-apple-darwin/libexec/../lib/libshaderc_shared.1.dylib' (no such file)

It seems that rust-analyzer dlopens the procedural macro, but the path to the `shaderc` library has been lost on the way.
To be honest the whole story around shared libraries is a bit over my head, so it's not clear to me what's working or not.

The fix I've found is to statically link `shaderc`. This uses the `prefer-static-linking` feature that was introduced in shaderc v0.8. I don't think that users care about the additional disk usage of static linking, given that this is a proc macro and not in the final binary.
